### PR TITLE
Add Lemonade inference client

### DIFF
--- a/minions/clients/__init__.py
+++ b/minions/clients/__init__.py
@@ -15,6 +15,7 @@ from minions.clients.llama_api import LlamaApiClient
 from minions.clients.mistral import MistralClient
 from minions.clients.sarvam import SarvamClient
 from minions.clients.docker_model_runner import DockerModelRunnerClient
+from minions.clients.lemonade import LemonadeClient
 
 __all__ = [
     "OllamaClient",
@@ -33,6 +34,7 @@ __all__ = [
     "MistralClient",
     "SarvamClient",
     "DockerModelRunnerClient",
+    "LemonadeClient",
 ]
 
 try:

--- a/minions/clients/lemonade.py
+++ b/minions/clients/lemonade.py
@@ -1,0 +1,103 @@
+import os
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+
+from minions.clients.openai import OpenAIClient
+
+
+class LemonadeClient(OpenAIClient):
+    """Client for interacting with a local Lemonade inference server.
+
+    This client uses the OpenAI compatible endpoints exposed by Lemonade
+    Server. Additional Lemonade specific endpoints such as ``pull`` and
+    ``load`` are also implemented via simple HTTP requests.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "Qwen2.5-0.5B-Instruct-CPU",
+        api_key: Optional[str] = None,
+        temperature: float = 0.0,
+        max_tokens: int = 2048,
+        base_url: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        base_url = base_url or os.getenv("LEMONADE_BASE_URL", "http://localhost:8000/api/v1")
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            base_url=base_url,
+            **kwargs,
+        )
+        # Session for the custom endpoints
+        self.session = requests.Session()
+        self.base_url = base_url
+        self.logger.setLevel(logging.INFO)
+
+    # ------------------------------------------------------------------
+    # Lemonade specific helper APIs
+    # ------------------------------------------------------------------
+    def get_models(self) -> Dict[str, Any]:
+        """Return models available on the server."""
+        resp = self.session.get(f"{self.base_url}/models")
+        resp.raise_for_status()
+        return resp.json()
+
+    def pull_model(self, model_name: str) -> Dict[str, Any]:
+        """Download and register a model on the server."""
+        resp = self.session.post(f"{self.base_url}/pull", json={"model_name": model_name})
+        resp.raise_for_status()
+        return resp.json()
+
+    def load_model(
+        self,
+        *,
+        model_name: Optional[str] = None,
+        checkpoint: Optional[str] = None,
+        recipe: Optional[str] = None,
+        reasoning: Optional[bool] = None,
+        mmproj: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Explicitly load a model into memory."""
+        payload: Dict[str, Any] = {}
+        if model_name:
+            payload["model_name"] = model_name
+        if checkpoint:
+            payload["checkpoint"] = checkpoint
+        if recipe:
+            payload["recipe"] = recipe
+        if reasoning is not None:
+            payload["reasoning"] = reasoning
+        if mmproj:
+            payload["mmproj"] = mmproj
+        resp = self.session.post(f"{self.base_url}/load", json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    def unload_model(self) -> Dict[str, Any]:
+        """Unload the currently loaded model."""
+        resp = self.session.post(f"{self.base_url}/unload")
+        resp.raise_for_status()
+        return resp.json()
+
+    def set_params(self, **params: Any) -> Dict[str, Any]:
+        """Set generation parameters that persist across requests."""
+        resp = self.session.post(f"{self.base_url}/params", json=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_health(self) -> Dict[str, Any]:
+        """Check the health of the server."""
+        resp = self.session.get(f"{self.base_url}/health")
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Return performance statistics from the last request."""
+        resp = self.session.get(f"{self.base_url}/stats")
+        resp.raise_for_status()
+        return resp.json()

--- a/tests/client_tests/test_lemonade_client_integration.py
+++ b/tests/client_tests/test_lemonade_client_integration.py
@@ -1,0 +1,44 @@
+"""Lemonade client integration tests."""
+
+import unittest
+import sys
+import os
+
+# Add the parent directory to the path so we can import minions
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+# Add the tests directory to the path for base class import
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from minions.clients.lemonade import LemonadeClient
+from test_base_client_integration import BaseClientIntegrationTest
+
+
+class TestLemonadeClientIntegration(BaseClientIntegrationTest):
+    CLIENT_CLASS = LemonadeClient
+    SERVICE_NAME = "lemonade"
+    DEFAULT_MODEL = "Qwen2.5-0.5B-Instruct-CPU"
+
+    def setUp(self):
+        """Set up Lemonade client if server URL provided."""
+        base_url = os.getenv("LEMONADE_BASE_URL")
+        if not base_url:
+            self.skipTest("LEMONADE_BASE_URL not set; skipping Lemonade tests")
+        self.client = self.CLIENT_CLASS(
+            model_name=self.DEFAULT_MODEL,
+            base_url=base_url,
+            temperature=0.1,
+            max_tokens=50,
+        )
+
+    def test_basic_chat(self):
+        """Test basic chat functionality."""
+        messages = self.get_test_messages()
+        result = self.client.chat(messages)
+
+        self.assert_valid_chat_response(result)
+        responses, _ = result
+        self.assert_response_content(responses, "test successful")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/env_checker.py
+++ b/tests/utils/env_checker.py
@@ -28,6 +28,7 @@ class APIKeyChecker:
         'cartesia': 'CARTESIA_API_KEY',
         'openrouter': 'OPENROUTER_API_KEY',
         'tokasaurus': 'TOKASAURUS_API_KEY',
+        'lemonade': 'LEMONADE_BASE_URL',
     }
     
     @classmethod


### PR DESCRIPTION
## Summary
- implement `LemonadeClient` for the Lemonade inference engine
- register the client in `__init__`
- allow tests to check for `LEMONADE_BASE_URL`
- add integration test template for the new client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6847537eb29c83259143e2873d1e5cf8