### PR TITLE
Enable Lemonade client for minions-a2a

### DIFF
--- a/apps/minions-a2a/a2a_minions/client_factory.py
+++ b/apps/minions-a2a/a2a_minions/client_factory.py
@@ -53,6 +53,7 @@ class ClientFactory:
         from minions.clients.deepseek import DeepSeekClient
         from minions.clients.groq import GroqClient
         from minions.clients.gemini import GeminiClient
+        from minions.clients.lemonade import LemonadeClient
         
         # Store references
         self.Minion = Minion
@@ -65,6 +66,7 @@ class ClientFactory:
             ProviderType.DEEPSEEK: DeepSeekClient,
             ProviderType.GROQ: GroqClient,
             ProviderType.GEMINI: GeminiClient,
+            ProviderType.LEMONADE: LemonadeClient,
         }
         
         # Try to import optional clients

--- a/apps/minions-a2a/a2a_minions/config.py
+++ b/apps/minions-a2a/a2a_minions/config.py
@@ -23,6 +23,7 @@ class ProviderType(str, Enum):
     DEEPSEEK = "deepseek"
     GEMINI = "gemini"
     GROQ = "groq"
+    LEMONADE = "lemonade"
     MLX = "mlx"
     CARTESIA_MLX = "cartesia-mlx"
 

--- a/apps/minions-a2a/requirements.txt
+++ b/apps/minions-a2a/requirements.txt
@@ -12,3 +12,4 @@ pymupdf>=1.23.0
 PyJWT>=2.8.0
 tabulate>=0.9.0
 prometheus-client>=0.19.0
+requests>=2.31.0

--- a/apps/minions-a2a/tests/unit/test_config.py
+++ b/apps/minions-a2a/tests/unit/test_config.py
@@ -31,6 +31,7 @@ class TestEnums(unittest.TestCase):
             ("deepseek", ProviderType.DEEPSEEK),
             ("gemini", ProviderType.GEMINI),
             ("groq", ProviderType.GROQ),
+            ("lemonade", ProviderType.LEMONADE),
             ("mlx", ProviderType.MLX),
             ("cartesia-mlx", ProviderType.CARTESIA_MLX)
         ]


### PR DESCRIPTION
## Summary
- add `LEMONADE` provider enum
- wire Lemonade client into the A2A client factory
- include requests dependency for A2A app
- update unit tests for new provider

## Testing
- `python apps/minions-a2a/tests/run_unit_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68475f045f788325915bb77d5de15f48